### PR TITLE
Fix main and types filename

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mathex2java-translator",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Transpiler to convert amsmath LaTeX to Java code.",
   "author": "Francisco Maria",
   "license": "GPL-2.0-or-later",
@@ -22,8 +22,8 @@
     "languages",
     "cfg"
   ],
-  "main": "dist/mathex2java.js",
-  "types": "dist/mathex2java.d.ts",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "directories": {
     "test": "tests"
   },


### PR DESCRIPTION
Fix both `main` and `types` properties as well as release 1.1.5.